### PR TITLE
chore(deps): bump Go + x/crypto to clear 2 critical SCAs (ENG-2122)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.25.10'
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dakota-xyz/recovery
 
-go 1.21
+go 1.25.10
 
 require (
 	github.com/blocto/solana-go-sdk v1.26.0
@@ -9,13 +9,13 @@ require (
 	github.com/hashicorp/vault v1.15.2
 	github.com/mr-tron/base58 v1.2.0
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/crypto v0.15.0
+	golang.org/x/crypto v0.31.0
 )
 
 require (
 	filippo.io/edwards25519 v1.0.0-rc.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	golang.org/x/sys v0.14.0 // indirect
+	golang.org/x/sys v0.28.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,10 +16,10 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-golang.org/x/crypto v0.15.0 h1:frVn1TEaCEaZcn3Tmd7Y2b5KKPaZ+I32Q2OA3kYp5TA=
-golang.org/x/crypto v0.15.0/go.mod h1:4ChreQoLWfG3xLDer1WdlH5NdlQ3+mwnQq1YTKY+72g=
-golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
-golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
+golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Summary

Closes **two** open critical-severity Datadog SCA findings on `recovery`:

| Advisory | Package | Was | Now |
|---|---|---|---|
| [GO-2026-4337](https://pkg.go.dev/vuln/GO-2026-4337) / CVE-2025-68121 | Go stdlib (`crypto/tls`) | `go 1.21` | `go 1.25.10` |
| [GHSA-v778-237x-gjrc](https://github.com/advisories/GHSA-v778-237x-gjrc) / CVE-2024-45337 | `golang.org/x/crypto` (SSH) | `v0.15.0` | `v0.31.0` |

Linear: [ENG-2122](https://linear.app/dakotaxyz/issue/ENG-2122/resolve-critical-sca-dependency-cves-in-recovery)

The x/crypto CVE is a real SSH `PublicKeyCallback` authorization bypass — patching this matters beyond just the SCA flag.

## Lockstep changes

* `go.mod` — Go directive and `x/crypto` version
* `go.sum` — refreshed by `go mod tidy`; also bumped `x/sys` from `v0.14.0` → `v0.28.0` transitively
* `.github/workflows/go.yml` — `go-version` from `'1.21'` to `'1.25.10'`

## Local verification

```
$ go build ./...   # OK
$ go test ./...    # 4 packages, all pass (cmd, ed25519, registry, secp256k1)
```

## Sibling PRs (same Go stdlib CVE)

Part of the org-wide SCA sweep — see siblings in policy-engine #71, provider #565, content-generation #27, dakota-qa #22, plus Waves 1 & 2 landing today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)